### PR TITLE
Made setPredicate:andPrepareBlock:forReuseIdentifier:

### DIFF
--- a/NXCollectionViewDataSource/NXCollectionViewDataSource/NXCollectionViewDataSource.h
+++ b/NXCollectionViewDataSource/NXCollectionViewDataSource/NXCollectionViewDataSource.h
@@ -34,6 +34,16 @@ typedef void(^NXCollectionViewDataSourcePostUpdateBlock)(NXCollectionViewDataSou
 @property (nonatomic, readonly, weak) UICollectionView *collectionView;
 
 #pragma mark Register Cell and Supplementary View Classes
+/*! Registers an already existing storyboard cell for items that match a specific predicate.
+    @param predicate        A predicate that is used to determine for which items the given cellClass is used. Every predicate will be collected with the given reuseIdentifier.
+                            All collected predicates will be iterated in the same order as they were registered. While generating the cells for the collection view, the first
+                            predicate/reuseIdentifier-pair that matches to the current item will be used for dequeuing the correct cell view from the collection view.
+                            The predicate will be evaluated with the variables "SECTION" and "ITEM", allowing to choose the cell based on the index path.
+    @param prepareBlock     A Block which is called to prepare the view. This block is called after the data source internally dequeues the view.
+    @param reuseIdentifier  The reuseIdentifier used by the existing storyboard cell.
+*/
+- (void)setPredicate:(NSPredicate *)predicate andPrepareBlock:(NXCollectionViewDataSourcePrepareBlock)prepareBlock forReuseIdentifier:(NSString *)reuseIdentifier;
+
 /*! Registers a Class used to create the cells for the collection view, for items that match a specific predicate.
  
     @param cellClass        The class of a cell that you want to use in the collection view.


### PR DESCRIPTION
Simply using the above function allows use of predesigned storyboard cells. 